### PR TITLE
Adding functionality to the Deceased-Info and Spouse pages, making changes based on feedback

### DIFF
--- a/web/src/components/home/PreQualification.vue
+++ b/web/src/components/home/PreQualification.vue
@@ -2,7 +2,7 @@
     <b-container class="container home-content" >
         <survey v-bind:survey="survey"></survey>
         <b-button v-if="displayButton" @click="onSubmit" variant="success">
-            <b-icon-check-circle-fill/> Create an Account
+            <b-icon-check-circle-fill/> Next
         </b-button>
 
         <b-modal size="xl" v-model="showDisclaimer" header-class="bg-white" no-close-on-backdrop hide-header-close>

--- a/web/src/components/home/PreQualification.vue
+++ b/web/src/components/home/PreQualification.vue
@@ -2,7 +2,7 @@
     <b-container class="container home-content" >
         <survey v-bind:survey="survey"></survey>
         <b-button v-if="displayButton" @click="onSubmit" variant="success">
-            <b-icon-check-circle-fill/> Complete
+            <b-icon-check-circle-fill/> Create an Account
         </b-button>
 
         <b-modal size="xl" v-model="showDisclaimer" header-class="bg-white" no-close-on-backdrop hide-header-close>

--- a/web/src/components/home/PreQualification.vue
+++ b/web/src/components/home/PreQualification.vue
@@ -91,7 +91,7 @@ export default class PreQualification extends Vue {
 
         if(!this.survey.isCurrentPageHasErrors) 
         {
-            if (this.survey.data.diedAfterWESA == 'y' && this.survey.data.complicationsExplanation > 0) 
+            if (this.survey.data.qualifyingWillExists == 'n' && this.survey.data.qualifyingDiedAfterWESA == 'y' && this.survey.data.qualifyingTerms > 0 ) 
             {
                 if(this.userId !== ""){
                     this.$router.push({ name: "surveys" });
@@ -109,7 +109,7 @@ export default class PreQualification extends Vue {
         this.survey.onValueChanged.add((sender, options) => { 
             console.log(this.survey.data) 
             console.log(options)        
-            if (this.survey.data.diedAfterWESA == 'y' && this.survey.data.complicationsExplanation) 
+            if (this.survey.data.qualifyingWillExists == 'n' && this.survey.data.qualifyingDiedAfterWESA == 'y' && this.survey.data.qualifyingTerms > 0 ) 
             {
                 this.displayButton = true;
             } else {

--- a/web/src/components/home/forms/survey-qualify.json
+++ b/web/src/components/home/forms/survey-qualify.json
@@ -1,163 +1,157 @@
 {
- "title": "Provincial Family Test",
- "pages": [
-  {
-   "name": "Qualifying Questions",
-   "elements": [
-    {
-     "type": "panel",
-     "name": "qualifyingIntroPanel",
-     "elements": [
-      {
-       "type": "infotext",
-       "name": "qualifyingIntroExplanation",
-       "title": "A `Representation Grant` costs money and will take time to get. Don't waste time on this service if you don't need one.\n<br><br>\nFor example, if the `deceased` had money in their bank account, that bank may give you that money to manage without a Representation Grant. However, this may depend on your relationship to the deceased. \n<br><br>\nDifferent organizations have different policies to make sure that the right person gets the deceased's assets.\n<br><br>\nAsk each of the organizations that hold the deceased's `assets` if they will give you the asset without a Representation Grant (also known as a Grant of `Probate`).",
-       "isRequired": true,
-       "titleLocation": "hidden"
-      }
-     ]
-    },
-    {
-     "type": "panel",
-     "name": "qualifyingNeedGrantPanel",
-     "elements": [
-      {
-       "type": "yesno",
-       "name": "needGrant",
-       "title": "Were you asked to get a `Representation Grant` (or a Grant of `Probate`) by any of the organizations that hold the `deceased's` `assets`",
-       "isRequired": true
-      },
-      {
-       "type": "infotext",
-       "name": "needGrantYesExplanation",
-       "visible": false,
-       "visibleIf": "{needGrant} = \"y\"",
-       "title": "The organizations that hold the `deceased's` `assets` will respect a `Representation Grant` and let you to manage the asset.\n<br><br>\nContinue with this service to apply for a Representation Grant.",
-       "isRequired": true,
-       "titleLocation": "hidden"
-      },
-      {
-       "type": "infotext",
-       "name": "needGrantNoExplanation",
-       "visible": false,
-       "visibleIf": "{needGrant} = \"n\"",
-       "title": "If all of the organizations that hold the `deceased's` `assets` simply gave you those assets to manage, then you probably don't need `Representation Grant`.",
-       "isRequired": true,
-       "titleLocation": "hidden"
-      },
-      {
-       "type": "yesno",
-       "name": "stillNeedGrant",
-       "visible": false,
-       "visibleIf": "{needGrant} = \"n\" and {needGrantNoExplanation} > 0",
-       "title": "Do you still want to use this service to apply for a `Representation Grant`"
-      },
-      {
-       "type": "infotext",
-       "name": "stillNeedGrantNoError",
-       "visible": false,
-       "visibleIf": "{needGrant} = \"n\" and {stillNeedGrant} = \"n\"",
-       "title": "It seems you don't need this service to manage the `deceased's` `assets`. \n<br><br>\nThe organizations that hold the deceased's assets may ask you to sign a waiver in case there are problems in the future.\n<br><br>\n Once you have the assets, you are responsible for distributing them according to the law.\n<br><br>\nIf the deceased made a `Will`, do your best to follow instruction in the Will on how to distribute the assets.\n<br><br>\nIf the deceased did not make a Will, there are rules written in the Wills, Estates and Succession Act (WESA Part 3 Division 1) on how to distribute the assets. There are different rules depending on the deceased's family situation. \n<br><br>\nRead the rules written in <a href=\"https://www.bclaws.ca/civix/document/id/lc/statreg/09013_01#division_d2e2469\" target=\"_blank\">WESA (Part 3 Division 1) here.</a> \n<br><br>\n[Jack to follow up with ServiceBC/Service Design & Integration to see if there is a better plain language resource]",
-       "titleLocation": "hidden",
-       "messageStyle": "error"
-      }
-     ],
-     "visible": false,
-     "visibleIf": "{qualifyingIntroExplanation} > 0"
-    },
-    {
-     "type": "panel",
-     "name": "qualifyingWillExistsPanel",
-     "elements": [
-      {
-       "type": "yesno",
-       "name": "qualifyingWillExists",
-       "title": "Do you believe the `deceased` made a `Will`",
-       "isRequired": true
-      },
-      {
-       "type": "infotext",
-       "name": "qualifyingWillExistsYesError",
-       "visible": false,
-       "visibleIf": "{qualifyingWillExists} = \"y\"",
-       "title": "If you believe the `deceased` made a `Will`, this service cannot help you apply for a `Representation Grant` at this point in time.\n<br><br>\nFor now, this service has only been developed for a limited number of situations.\n<br><br>\n[Jack to decide what additional help text is required here]",
-       "titleLocation": "hidden",
-       "messageStyle": "error"
-      }
-     ],
-     "visible": false,
-     "visibleIf": "({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")"
-    },
-    {
-     "type": "panel",
-     "name": "qualifyingAfterWESAPanel",
-     "elements": [
-      {
-       "type": "yesno",
-       "name": "diedAfterWESA",
-       "title": "Did the `deceased` die after March 30, 2014?",
-       "isRequired": true
-      },
-      {
-       "type": "infotext",
-       "name": "diedAfterWESANoError",
-       "visible": false,
-       "visibleIf": "{diedAfterWESA} = \"n\"",
-       "title": "At this point in time, this service cannot help you apply for a `Representation Grant` if the `deceased` died on March 30, 2014, or before. \n<br><br>\nThe Wills, Estate and Succession Act became law on March 31, 2014. This service only supports the current laws. \n<br><br>\nIf the deceased died before to the current Wills, Estate and Succession Act became law, your `application` also needs to comply with the old Estate Administration Act. \n<br><br>\nPlease review both sets of laws to make sure your application will be successful.\n<ul>\n<li>the <a href=\"http://www.bclaws.ca/civix/document/id/consol17/consol17/00_96122_01\" target=\"blank\">Estate Administration Act</a> </li>\n<li>the <a href=\"http://www.bclaws.ca/civix/document/id/complete/statreg/09013_01\" target=\"blank\">Wills, Estate and Succession Act</a> </li> \n</ul>",
-       "titleLocation": "hidden",
-       "messageStyle": "error"
-      }
-     ],
-     "visible": false,
-     "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\""
-    },
-    {
-        "type": "panel",
-        "name": "qualifyingTermsPanel",
-        "elements": [
-            {
-                "type": "checkbox",
-                "name": "qualifyingTerms",
-                "title": "This service can help you apply for a `Representation Grant`. Before continuing, please read the terms of using this service.\n<br><br>\n\"Apply to Represent Someone Who Died\" is a service provided by the Government of British Columbia.\n<br><br>\nThe Government of British Columbia has the right to change this service at any time.\n<br><br>\n<ul>\n<li>Learn more about <a href=\"https://www2.gov.bc.ca/gov/content/home/disclaimer\" target=\"_blank\">the disclaimer and liability here.</a> (This link opens in a new tab)</li>\n<li>Learn more about <a href=\"https://www2.gov.bc.ca/gov/content/home/privacy\" target=\"_blank\">privacy and security here.</a> (This link opens in a new tab)</li>\n</ul>\nThe Supreme Court of British Columbia will review your `application`. The Court will decide to give you a `Representation Grant` or not.",
-                "isRequired": true,
-                "choices": [
-                    {
-                        "value": "agree",
-                        "text": "I agree to these terms"
-                    }
-                ]
-            }
-        ],
-        "visible": false,
-        "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\" and {diedAfterWESA} = \"y\" "       
-    },
-    {
-     "type": "panel",
-     "name": "qualifyingComplicationsPanel",
-     "elements": [
-      {
-       "type": "infotext",
-       "name": "complicationsExplanation",
-       "title": "This service can help you apply for a `Representation Grant`.\n<br><br>\nThe next step is to create an account so that you can save your progress as you work through this service.",
-       "isRequired": true,
-       "titleLocation": "hidden"
-      },
-      {
-       "type": "infotext",
-       "name": "complicationsExplanationFutureScope",
-       "visible": false,
-       "title": "This service can help you apply for a `Representation Grant` whether the `deceased` made a `Will` or not. \n<br><br>\nAt this point in time, this service has been developed for the most common situations.\n<br><br>\nIf your situation is unusual, this service may still be able to help you. You will be able to ask the developer of this service if they can include your specific situation.\n<br><br>\nThe next step is to create an account so that you can save your progress as you work through this service.",
-       "titleLocation": "hidden"
-      }      
-     ],
-     "visible": false,
-     "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\" and {diedAfterWESA} = \"y\" and {qualifyingTerms[0]}='agree'"
-    }
-   
-   ],
-   "title": "Is this service right for your situation?"
-  }
- ],
- "showQuestionNumbers": "off",
- "requiredText": ""
+    "title": "Provincial Family Test",
+    "pages": [
+        {
+            "name": "Qualifying Questions",
+            "elements": [
+                {
+                    "type": "panel",
+                    "name": "qualifyingIntroPanel",
+                    "elements": [
+                        {
+                            "type": "infotext",
+                            "name": "qualifyingIntroExplanation",
+                            "title": "A `Representation Grant` costs money and will take time to get. Don't waste time on this service if you don't need one.\n<br><br>\nFor example, if the `deceased` had money in their bank account, that bank may give you that money to manage without a Representation Grant. However, this may depend on your relationship to the deceased. \n<br><br>\nDifferent organizations have different policies to make sure that the right person gets the deceased's assets.\n<br><br>\nAsk each of the organizations that hold the deceased's `assets` if they will give you the asset without a Representation Grant (also known as a Grant of `Probate`).",
+                            "isRequired": true,
+                            "titleLocation": "hidden"
+                        }
+                    ]
+                },
+                {
+                    "type": "panel",
+                    "name": "qualifyingNeedGrantPanel",
+                    "elements": [
+                        {
+                            "type": "yesno",
+                            "name": "needGrant",
+                            "title": "Were you asked to get a `Representation Grant` (or a Grant of `Probate`) by any of the organizations that hold the `deceased's` `assets`",
+                            "isRequired": true
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "needGrantYesExplanation",
+                            "visible": false,
+                            "visibleIf": "{needGrant} = \"y\"",
+                            "title": "The organizations that hold the `deceased's` `assets` will respect a `Representation Grant` and let you to manage the asset.\n<br><br>\nContinue with this service to apply for a Representation Grant.",
+                            "isRequired": true,
+                            "titleLocation": "hidden"
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "needGrantNoExplanation",
+                            "visible": false,
+                            "visibleIf": "{needGrant} = \"n\"",
+                            "title": "If all of the organizations that hold the `deceased's` `assets` simply gave you those assets to manage, then you probably don't need `Representation Grant`.",
+                            "isRequired": true,
+                            "titleLocation": "hidden"
+                        },
+                        {
+                            "type": "yesno",
+                            "name": "stillNeedGrant",
+                            "visible": false,
+                            "visibleIf": "{needGrant} = \"n\" and {needGrantNoExplanation} > 0",
+                            "title": "Do you still want to use this service to apply for a `Representation Grant`"
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "stillNeedGrantNoError",
+                            "visible": false,
+                            "visibleIf": "{needGrant} = \"n\" and {stillNeedGrant} = \"n\"",
+                            "title": "It seems you don't need this service to manage the `deceased's` `assets`. \n<br><br>\nThe organizations that hold the deceased's assets may ask you to sign a waiver in case there are problems in the future.\n<br><br>\n Once you have the assets, you are responsible for distributing them according to the law.\n<br><br>\nIf the deceased made a `Will`, do your best to follow instruction in the Will on how to distribute the assets.\n<br><br>\nIf the deceased did not make a Will, there are rules written in the Wills, Estates and Succession Act (WESA Part 3 Division 1) on how to distribute the assets. There are different rules depending on the deceased's family situation. \n<br><br>\nRead the rules written in <a href=\"https://www.bclaws.ca/civix/document/id/lc/statreg/09013_01#division_d2e2469\" target=\"_blank\">WESA (Part 3 Division 1) here.</a> (This link opens in a new tab)\n<br><br>\n[Jack to follow up with ServiceBC/Service Design & Integration to see if there is a better plain language resource]",
+                            "titleLocation": "hidden",
+                            "messageStyle": "error"
+                        }
+                    ],
+                    "visible": false,
+                    "visibleIf": "{qualifyingIntroExplanation} > 0"
+                },
+                {
+                    "type": "panel",
+                    "name": "qualifyingWillExistsPanel",
+                    "elements": [
+                        {
+                            "type": "yesno",
+                            "name": "qualifyingWillExists",
+                            "title": "Do you believe the `deceased` made a `Will`",
+                            "isRequired": true
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "qualifyingWillExistsYesError",
+                            "visible": false,
+                            "visibleIf": "{qualifyingWillExists} = \"y\"",
+                            "title": "If you believe the `deceased` made a `Will`, this service cannot help you apply for a `Representation Grant` at this point in time.\n<br><br>\nFor now, this service has only been developed for a limited number of situations.\n<br><br>\n[Jack to decide what additional help text is required here]",
+                            "titleLocation": "hidden",
+                            "messageStyle": "error"
+                        }
+                    ],
+                    "visible": false,
+                    "visibleIf": "({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")"
+                },
+                {
+                    "type": "panel",
+                    "name": "qualifyingAfterWESAPanel",
+                    "elements": [
+                        {
+                            "type": "yesno",
+                            "name": "qualifyingDiedAfterWESA",
+                            "title": "Did the `deceased` die after March 30, 2014?",
+                            "isRequired": true
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "qualifyingDiedAfterWESANoError",
+                            "visible": false,
+                            "visibleIf": "{qualifyingDiedAfterWESA} = \"n\"",
+                            "title": "At this point in time, this service cannot help you apply for a `Representation Grant` if the `deceased` died on March 30, 2014, or before. \n<br><br>\nThe Wills, Estate and Succession Act became law on March 31, 2014. This service only supports the current laws. \n<br><br>\nIf the deceased died before to the current Wills, Estate and Succession Act became law, your `application` also needs to comply with the old Estate Administration Act. \n<br><br>\nPlease review both sets of laws to make sure your application will be successful.\n<ul>\n<li>the <a href=\"http://www.bclaws.ca/civix/document/id/consol17/consol17/00_96122_01\" target=\"blank\">Estate Administration Act</a> (This link opens in a new tab)</li>\n<li>the <a href=\"http://www.bclaws.ca/civix/document/id/complete/statreg/09013_01\" target=\"blank\">Wills, Estate and Succession Act</a> (This link opens in a new tab)</li> \n</ul>",
+                            "titleLocation": "hidden",
+                            "messageStyle": "error"
+                        }
+                    ],
+                    "visible": false,
+                    "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\""
+                },
+                {
+                    "type": "panel",
+                    "name": "qualifyingTermsPanel",
+                    "elements": [
+                        {
+                            "isRequired": true,
+                            "messageStyle": "inline",
+                            "name": "qualifyingTerms",
+                            "title": "This service can help you apply for a `Representation Grant`. Before continuing, please read the terms for using this service.\n<br><br>\n\"Apply to Represent Someone Who Died\" is a service provided by the Government of British Columbia.\n<br><br>\nThe Government of British Columbia has the right to change this service at any time.\n<br><br>\n<ul>\n<li>Learn more about <a href=\"https://www2.gov.bc.ca/gov/content/home/disclaimer\" target=\"_blank\">the disclaimer and liability here.</a> (This link opens in a new tab)</li>\n<li>Learn more about <a href=\"https://www2.gov.bc.ca/gov/content/home/privacy\" target=\"_blank\">privacy and security here.</a> (This link opens in a new tab)</li>\n</ul>\nThe Supreme Court of British Columbia will review your `application`. The Court will decide to give you a Representation Grant or not.\n<br><br>\nBy pressing \"Continue\", you are agreeing to these terms.",
+                            "titleLocation": "hidden",
+                            "type": "infotext"
+                        }
+                    ],
+                    "visible": false,
+                    "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\" and {qualifyingDiedAfterWESA} = \"y\" "
+                },
+                {
+                    "type": "panel",
+                    "name": "qualifyingComplicationsPanel",
+                    "elements": [
+                        {
+                            "name": "qualifyingComplicationsExplanation",
+                            "title": "The next step is to create an account so that you can save your progress as you work through this service.",
+                            "titleLocation": "hidden",
+                            "type": "infotext"
+                        },
+                        {
+                            "name": "qualifyingComplicationsExplanationFutureScope",
+                            "title": "This service can help you apply for a `Representation Grant` whether the `deceased` made a `Will` or not. \n<br><br>\nAt this point in time, this service has been developed for the most common situations.\n<br><br>\nIf your situation is unusual, this service may still be able to help you. You will be able to ask the developer of this service if they can include your specific situation.\n<br><br>\nThe next step is to create an account so that you can save your progress as you work through this service.",
+                            "titleLocation": "hidden",
+                            "type": "infotext",
+                            "visible": false
+                        }
+                    ],
+                    "visible": false,
+                    "visibleIf": "(({needGrant} = \"y\" and {needGrantYesExplanation} > 0) or ({needGrant} = \"n\" and {stillNeedGrant} = \"y\")) and {qualifyingWillExists} = \"n\" and {qualifyingDiedAfterWESA} = \"y\" and {qualifyingTerms}>0"
+                }
+            ],
+            "title": "Is this service right for your situation?"
+        }
+    ],
+    "showQuestionNumbers": "off",
+    "requiredText": ""
 }

--- a/web/src/components/steps/deceased/forms/deceased-info.json
+++ b/web/src/components/steps/deceased/forms/deceased-info.json
@@ -160,14 +160,16 @@
                      "type": "infotext",
                      "name": "question438",
                      "title": "[Obsolete - Will questions determine which asset affidavit to use regardless of where the address is]\n<br><br>\nThis service can help you extend the powers of a `Representation Grant` from another place.\n<br><br>\nIt makes sense to first get a `Representation Grant` from where {deceasedName} spent most of their time. There may be benefits to getting grants in this order that a lawyer can explain to you. [link to lawyer info]\n<br><br>\nIf you don't already have a Representation Grant from the place where {deceasedName} spent most of their time, this service can still help you apply for a B.C. Representation Grant.  ",
-                     "titleLocation": "hidden"
+                     "titleLocation": "hidden",
+                     "visible":false
                   },
                   {
                      "type": "infotext",
                      "name": "question398",
                      "title": "[Obsolete?? Probably still useful if not for P10/P11 then service addresses] <a href=\"https://justice.gov.bc.ca/jira/browse/REPGRANT-3X\" target=\"_blank\">JIRA ticket REPGRANT3X - Location Trigger</a>\n<br><br>TB Finished\nMay need location data to figure out which asset form to use: P10 or P11",
                      "titleLocation": "hidden",
-                     "messageStyle": "error"
+                     "messageStyle": "error",
+                     "visible":false
                   },
                   {
                      "type": "infotext",

--- a/web/src/components/steps/deceased/forms/deceased-info.json
+++ b/web/src/components/steps/deceased/forms/deceased-info.json
@@ -49,7 +49,7 @@
                      "title": "<a href=\"https://justice.gov.bc.ca/jira/browse/REPGRANT-28\" target=\"_blank\">JIRA ticket REPGRANT-28 - Name Capitalization based on Input Device</a>",
                      "titleLocation": "hidden",
                      "messageStyle": "error",
-                     "visible":false
+                     "visible": false
                   }
                ],
                "visible": false,
@@ -109,15 +109,15 @@
                      "name": "deceasedDateOfDeathFAQ1",
                      "title": "How do I get a `Certificate of Death`",
                      "titleLocation": "hidden",
-                     "body": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. \n<br>\nYou can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n\nVisit the Government of British Columbia website for more information. https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\n\n<br><br>\nIf {deceasedName} died outside of British Columbia but still in Canada, you must get a Certificate of Death from the province or territory where they died. \n\n<br><br>\nClick here for other Vital Statistics Agencies in Canada. \nhttps://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\n\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n"
+                     "body": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. You can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n<br><br>\n<a href=\"https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\" target=\"_blank\">Click here for more information from the Government of British Columbia's website.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of British Columbia but still inside of Canada, you must get a Certificate of Death from the province or territory where they died. \n<br><br>\n<a href=\"https://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\" target=\"_blank\">Click here for other Vital Statistics Agencies in Canada.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. "
                   },
                   {
                      "type": "infotext",
                      "name": "question412",
-                     "title": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. \n<br>\nYou can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n\nVisit the Government of British Columbia website for more information. https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\n\n<br><br>\nIf {deceasedName} died outside of British Columbia but still in Canada, you must get a Certificate of Death from the province or territory where they died. \n\n<br><br>\nClick here for other Vital Statistics Agencies in Canada. \nhttps://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\n\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n",
+                     "title": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. You can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n<br><br>\n<a href=\"https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\" target=\"_blank\">Click here for more information from the Government of British Columbia's website.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of British Columbia but still inside of Canada, you must get a Certificate of Death from the province or territory where they died. \n<br><br>\n<a href=\"https://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\" target=\"_blank\">Click here for other Vital Statistics Agencies in Canada.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n",
                      "titleLocation": "hidden",
                      "visible": false
-                  },                  
+                  },
                   {
                      "type": "infotext",
                      "name": "jiraRepgrant32",
@@ -137,7 +137,7 @@
                   {
                      "type": "address",
                      "name": "deceasedAddress",
-                     "title": "What was {deceasedName} last known address?",
+                     "title": "What was {deceasedName}'s last known address?",
                      "description": "If {deceasedName} was homeless:\n<ul>\n<li>write \"no fixed address\" for the street address</li>\n<li>Write the city/town, province and country where they lived.</li>\n<li>Write \"n/a\" for their postal code.</li>\n</ul>"
                   },
                   {
@@ -159,17 +159,9 @@
                   {
                      "type": "infotext",
                      "name": "question438",
-                     "title": "[Obsolete - Will questions determine which asset affidavit to use regardless of where the address is]\n<br><br>\nThis service can help you extend the powers of a `Representation Grant` from another place.\n<br><br>\nIt makes sense to first get a `Representation Grant` from where {deceasedName} spent most of their time. There may be benefits to getting grants in this order that a lawyer can explain to you. [link to lawyer info]\n<br><br>\nIf you don't already have a Representation Grant from the place where {deceasedName} spent most of their time, this service can still help you apply for a B.C. Representation Grant.  ",
+                     "title": "[Location triggered Explanation Obsolete here?? - Will questions determine which asset affidavit to use regardless of where the address is]\n<br><br>\nThis service can help you extend the powers of a `Representation Grant` from another place.\n<br><br>\nIt makes sense to first get a `Representation Grant` from where {deceasedName} spent most of their time. There may be benefits to getting grants in this order that a lawyer can explain to you. [link to lawyer info]\n<br><br>\nIf you don't already have a Representation Grant from the place where {deceasedName} spent most of their time, this service can still help you apply for a B.C. Representation Grant.  ",
                      "titleLocation": "hidden",
-                     "visible":false
-                  },
-                  {
-                     "type": "infotext",
-                     "name": "question398",
-                     "title": "[Obsolete?? Probably still useful if not for P10/P11 then service addresses] <a href=\"https://justice.gov.bc.ca/jira/browse/REPGRANT-3X\" target=\"_blank\">JIRA ticket REPGRANT3X - Location Trigger</a>\n<br><br>TB Finished\nMay need location data to figure out which asset form to use: P10 or P11",
-                     "titleLocation": "hidden",
-                     "messageStyle": "error",
-                     "visible":false
+                     "visible": false
                   },
                   {
                      "type": "infotext",
@@ -218,14 +210,23 @@
                         "Uchucklesaht",
                         "Ucluelet"
                      ]
-                  },                  
+                  },
                   {
                      "type": "infotext",
-                     "name": "question460",
+                     "name": "deceasedFirstNationsNotifyExplanation",
                      "visible": false,
-                     "title": "This service will tell you how to notify the Nation in a later step.",
+                     "visibleIf": "{deceasedFirstNations} =\"y\" and {deceasedFirstNationsName} notempty",
+                     "title": "This service will tell you how to notify the {deceasedFirstNationsName} Nation in a later step.",
                      "isRequired": true,
                      "titleLocation": "hidden"
+                  },
+                  {
+                     "type": "infotext",
+                     "name": "question13",
+                     "visible": false,
+                     "title": "double check that the variable substitution from {deceasedFirstNationsName} updates in real-time in the deployed version for {deceasedFirstNationsNotifyExplanation}",
+                     "titleLocation": "hidden",
+                     "messageStyle": "error"
                   }
                ],
                "visible": false,
@@ -243,7 +244,7 @@
                   }
                ],
                "visible": false,
-               "visibleIf": "{deceasedName} notempty and {deceasedDateOfDeath} notempty and (!{invalidDateOfDeathError}) and {deceasedAddress} notempty and (({deceasedFirstNations} = \"n\") or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty))"
+               "visibleIf": "{deceasedName} notempty and {deceasedDateOfDeath} notempty and (!{invalidDateOfDeathError}) and {deceasedAddress} notempty and (({deceasedFirstNations} = \"n\") or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty and {deceasedFirstNationsNotifyExplanation} >0))"
             }
          ],
          "title": "Information about {deceasedName}"

--- a/web/src/components/steps/relatedPeople/forms/spouse.json
+++ b/web/src/components/steps/relatedPeople/forms/spouse.json
@@ -130,8 +130,7 @@
                      "name": "spouseIsCompetent",
                      "visible": false,
                      "visibleIf": "{panel.spouseIsAlive} = \"y\" and ({panel.spouseIsAdult} = \"y\" or ({panel.spouseIsAdult} = \"n\" and {panel.spouseHasGuardian} = \"n\"))",
-                     "title": "Is {panel.spouseName} `mentally competent`?",
-                     "description": "Update this logic so that living guardian comes here as well."
+                     "title": "Is {panel.spouseName} `mentally competent`?"
                   },
                   {
                      "type": "infotext",

--- a/web/src/components/steps/relatedPeople/forms/spouse.json
+++ b/web/src/components/steps/relatedPeople/forms/spouse.json
@@ -51,7 +51,7 @@
                   },
                   {
                      "type": "helptext",
-                     "name": "question28",
+                     "name": "spouseExistsFAQ2",
                      "title": "ask-erin about common-law and separated for less than 1? year but not yet divorced",
                      "description": "better to include person than no. if you're not sure, include them. \n<br><br>\nif separated, likely not going to get anything under WESA. No noticed required. This spouse's entitlement to {deceasedName}'s belongings will be through FLA. A different court.\n\nWESA\nhttp://www.bclaws.ca/civix/document/id/lc/statreg/09013_01#section2\n\nFamily Law Act 84\nhttp://www.bclaws.ca/civix/document/id/complete/statreg/11025_05#section84",
                      "titleLocation": "hidden"
@@ -70,14 +70,17 @@
             {
                "type": "paneldynamic",
                "name": "spouseInfoPanel",
-               "title":" ",
+               "title": " ",
                "visible": false,
                "visibleIf": "{spouseExists} = \"y\"",
                "templateElements": [
                   {
-                     "type": "text",
+                     "type": "personname",
                      "name": "spouseName",
-                     "title": "Please enter the full name of {deceasedName}'s `spouse`."
+                     "defaultSubstitution": "{deceasedName}'s spouse",
+                     "title": "Please enter the full name of {deceasedName}'s `spouse`.",
+                     "labelFirstName": "First Name (Given Name)",
+                     "labelLastName": "Last Name (Family Name or Surname)"
                   },
                   {
                      "type": "yesno",
@@ -168,7 +171,7 @@
                      "name": "spouseDied5DaysAfter",
                      "visible": false,
                      "visibleIf": "{panel.spouseIsAlive} = \"n\"",
-                     "title": "Did  die after {deceasedDateOfDeathPlus4}?"
+                     "title": "Did {panel.spouseName} die after {deceasedDateOfDeathPlus4}?"
                   },
                   {
                      "type": "helptext",
@@ -181,7 +184,14 @@
                   },
                   {
                      "type": "infotext",
-                     "name": "question13",
+                     "name": "spouseDied5DaysAfterNo",
+                     "visible": false,
+                     "title": "Because {panel.spouseName} did not die after {deceasedDateOfDeathPlus4}, the people managing {panel.spouseName}'s belongings do not need to be notified that you are applying for a `Representation Grant` for {deceasedName}.",
+                     "titleLocation": "hidden"
+                  },
+                  {
+                     "type": "infotext",
+                     "name": "question28",
                      "visible": false,
                      "title": "no - died \"before\" pretend they are dead, no notice. even if they died after, but before 4 days, no notice. pretend they died after.",
                      "titleLocation": "hidden"
@@ -251,19 +261,20 @@
                      "name": "spouseCompleted",
                      "visible": false,
                      "visibleIf": "{spouseIsYou} = \"n\" or ({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\")",
-                     "title": "Have you included anyone who may be considered a `spouse` of {deceasedName}?  "
+                     "title": "Have you included everyone who may be considered a `spouse` of {deceasedName}?  "
                   },
                   {
                      "type": "infotext",
                      "name": "spouseCompletedNoError",
                      "visible": false,
-                     "visibleIf": "{spouseIsYou} = \"n\" or ({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\") and {spouseCompleted} = \"n\"",
+                     "visibleIf": "{spouseCompleted} = \"n\"",
                      "title": "Please make sure to include anyone who may be considered a spouse of {deceasedName}.  It is important to identify your relationship to <Deceased Name> as this service will prepare the paperwork based on this information.",
                      "titleLocation": "hidden",
                      "messageStyle": "error"
                   }
                ],
-               "visible": false
+               "visible": false,
+               "visibleIf": "{spouseExists} = \"n\"\nor\n\n{spouseInfoPanel[0].spouseName} notempty \nand \n\n({spouseInfoPanel[0].spouseIsAlive} = \"y\" \nand\n\n({spouseInfoPanel[0].spouseIsAdult} = \"y\" \nor \n({spouseInfoPanel[0].spouseIsAdult} = \"n\" and {spouseInfoPanel[0].spouseHasGuardian} = \"n\")\nor\n({spouseInfoPanel[0].spouseIsAdult} = \"n\" and {spouseInfoPanel[0].spouseHasGuardian} = \"y\" and {spouseInfoPanel[0].spouseGuardianName} notempty))\nand \n\n({spouseInfoPanel[0].spouseIsCompetent} = \"y\" \nor\n({spouseInfoPanel[0].spouseIsCompetent} = \"n\" and\n{spouseInfoPanel[0].spouseHasCommittee} = \"n\" and \n{spouseInfoPanel[0].spouseInformalCommitteeName} notempty)\nor\n({spouseInfoPanel[0].spouseIsCompetent} = \"n\" and\n{spouseInfoPanel[0].spouseHasCommittee} = \"y\" and \n{spouseInfoPanel[0].spouseCommitteeName} notempty)))\n\nor\n\n({spouseInfoPanel[0].spouseIsAlive} = \"n\" \nand\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"n\"\nor\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"y\" and\n{spouseInfoPanel[0].spouseHasPersonalRep} = \"n\" and\n{spouseInfoPanel[0].spouseInformalPersonalRepName} notempty)\nor\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"y\" and\n{spouseInfoPanel[0].spouseHasPersonalRep} = \"y\" and\n{spouseInfoPanel[0].spousePersonalRepName} notempty)))\n\n"
             },
             {
                "type": "panel",
@@ -277,7 +288,7 @@
                   }
                ],
                "visible": false,
-               "visibleIf": "{spouseExists} = 'n' or ({spouseExists} = 'y' and {spouseIsYou} = 'n') or ({spouseIsYou} = 'y' and {spouseIsYouIncluded} = 'y')"
+               "visibleIf": "({spouseIsYou} = \"n\" or \n({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\"))\nand \n{spouseCompleted} = \"y\""
             }
          ],
          "title": "{deceasedName}'s Spouse"

--- a/web/src/components/steps/survey-primary.json
+++ b/web/src/components/steps/survey-primary.json
@@ -96,11 +96,6 @@
                             "dateYearsBehind": 6
                         },
                         {
-                            "type": "text",
-                            "name": "question253",
-                            "title": "survivorship rule date test {deceasedDateOfDeathPlus4}"
-                        },
-                        {
                             "type": "helptext",
                             "name": "deceasedDateOfDeathFAQ1",
                             "title": "How do I get a `Certificate of Death`",
@@ -239,7 +234,7 @@
                         }
                     ],
                     "visible": false,
-                    "visibleIf": "{deceasedName} notempty and ({deceasedNameReplace} = \"n\" or ({deceasedNameReplace} = \"y\" and {deceasedNickname} notempty)) and {deceasedDateOfDeath} notempty and {deceasedAddress} notempty and ({deceasedFirstNations} = \"n\" or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty}))"
+                    "visibleIf": "{deceasedName} notempty and {deceasedDateOfDeath} notempty and {deceasedAddress} notempty and ({deceasedFirstNations} = \"n\" or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty))"
                 }
             ],
             "title": "Information about {deceasedName}"
@@ -5324,14 +5319,15 @@
                             "title": "Will version TBD: copy their names as they appear on the will.\n<br>\nFuture, note about if you already entered yourself as executor, do so again here.",
                             "isRequired": true,
                             "titleLocation": "hidden"
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "question41",
+                            "visible": false,
+                            "title": "What if the spouse is the executor and already put their info in the executor page?",
+                            "titleLocation": "hidden"
                         }
                     ]
-                },
-                {
-                    "type": "infotext",
-                    "name": "question41",
-                    "title": "What if the spouse is the executor and already put their info in the executor page?",
-                    "titleLocation": "hidden"
                 },
                 {
                     "type": "panel",
@@ -5352,7 +5348,7 @@
                         },
                         {
                             "type": "helptext",
-                            "name": "question28",
+                            "name": "spouseExistsFAQ2",
                             "title": "ask-erin about common-law and separated for less than 1? year but not yet divorced",
                             "description": "better to include person than no. if you're not sure, include them. \n<br><br>\nif separated, likely not going to get anything under WESA. No noticed required. This spouse's entitlement to {deceasedName}'s belongings will be through FLA. A different court.\n\nWESA\nhttp://www.bclaws.ca/civix/document/id/lc/statreg/09013_01#section2\n\nFamily Law Act 84\nhttp://www.bclaws.ca/civix/document/id/complete/statreg/11025_05#section84",
                             "titleLocation": "hidden"
@@ -5468,7 +5464,7 @@
                             "name": "spouseDied5DaysAfter",
                             "visible": false,
                             "visibleIf": "{panel.spouseIsAlive} = \"n\"",
-                            "title": "Did  die after (Deceased Date of Death + 4 days)?"
+                            "title": "Did {panel.spouseName} die after {deceasedDateOfDeathPlus4}?"
                         },
                         {
                             "type": "helptext",
@@ -5481,7 +5477,14 @@
                         },
                         {
                             "type": "infotext",
-                            "name": "question13",
+                            "name": "spouseDied5DaysAfterNo",
+                            "visible": false,
+                            "title": "Because {panel.spouseName} did not die after {deceasedDateOfDeathPlus4}, the people managing {panel.spouseName}'s belongings do not need to be notified that you are applying for a `Representation Grant` for {deceasedName}.",
+                            "titleLocation": "hidden"
+                        },
+                        {
+                            "type": "infotext",
+                            "name": "question28",
                             "visible": false,
                             "title": "no - died \"before\" pretend they are dead, no notice. even if they died after, but before 4 days, no notice. pretend they died after.",
                             "titleLocation": "hidden"
@@ -5551,19 +5554,20 @@
                             "name": "spouseCompleted",
                             "visible": false,
                             "visibleIf": "{spouseIsYou} = \"n\" or ({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\")",
-                            "title": "Have you included anyone who may be considered a `spouse` of {deceasedName}?  "
+                            "title": "Have you included everyone who may be considered a `spouse` of {deceasedName}?  "
                         },
                         {
                             "type": "infotext",
                             "name": "spouseCompletedNoError",
                             "visible": false,
-                            "visibleIf": "{spouseIsYou} = \"n\" or ({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\") and {spouseCompleted} = \"n\"",
+                            "visibleIf": "{spouseCompleted} = \"n\"",
                             "title": "Please make sure to include anyone who may be considered a spouse of {deceasedName}.  It is important to identify your relationship to <Deceased Name> as this service will prepare the paperwork based on this information.",
                             "titleLocation": "hidden",
                             "messageStyle": "error"
                         }
                     ],
-                    "visible": false
+                    "visible": false,
+                    "visibleIf": "{spouseExists} = \"n\"\nor\n\n{spouseInfoPanel[0].spouseName} notempty \nand \n\n({spouseInfoPanel[0].spouseIsAlive} = \"y\" \nand\n\n({spouseInfoPanel[0].spouseIsAdult} = \"y\" \nor \n({spouseInfoPanel[0].spouseIsAdult} = \"n\" and {spouseInfoPanel[0].spouseHasGuardian} = \"n\")\nor\n({spouseInfoPanel[0].spouseIsAdult} = \"n\" and {spouseInfoPanel[0].spouseHasGuardian} = \"y\" and {spouseInfoPanel[0].spouseGuardianName} notempty))\nand \n\n({spouseInfoPanel[0].spouseIsCompetent} = \"y\" \nor\n({spouseInfoPanel[0].spouseIsCompetent} = \"n\" and\n{spouseInfoPanel[0].spouseHasCommittee} = \"n\" and \n{spouseInfoPanel[0].spouseInformalCommitteeName} notempty)\nor\n({spouseInfoPanel[0].spouseIsCompetent} = \"n\" and\n{spouseInfoPanel[0].spouseHasCommittee} = \"y\" and \n{spouseInfoPanel[0].spouseCommitteeName} notempty)))\n\nor\n\n({spouseInfoPanel[0].spouseIsAlive} = \"n\" \nand\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"n\"\nor\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"y\" and\n{spouseInfoPanel[0].spouseHasPersonalRep} = \"n\" and\n{spouseInfoPanel[0].spouseInformalPersonalRepName} notempty)\nor\n({spouseInfoPanel[0].spouseDied5DaysAfter} = \"y\" and\n{spouseInfoPanel[0].spouseHasPersonalRep} = \"y\" and\n{spouseInfoPanel[0].spousePersonalRepName} notempty)))\n\n"
                 },
                 {
                     "type": "panel",
@@ -5577,7 +5581,7 @@
                         }
                     ],
                     "visible": false,
-                    "visibleIf": "{spouseExists} = 'n' or ({spouseExists} = 'y' and {spouseIsYou} = 'n') or ({spouseIsYou} = 'y' and {spouseIsYouIncluded} = 'y')"
+                    "visibleIf": "({spouseIsYou} = \"n\" or \n({spouseIsYou} = \"y\" and {spouseIsYouIncluded} = \"y\"))\nand \n{spouseCompleted} = \"y\""
                 }
             ],
             "title": "{deceasedName}'s Spouse"

--- a/web/src/components/steps/survey-primary.json
+++ b/web/src/components/steps/survey-primary.json
@@ -100,13 +100,13 @@
                             "name": "deceasedDateOfDeathFAQ1",
                             "title": "How do I get a `Certificate of Death`",
                             "titleLocation": "hidden",
-                            "body": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. \n<br>\nYou can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n\nVisit the Government of British Columbia website for more information. https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\n\n<br><br>\nIf {deceasedName} died outside of British Columbia but still in Canada, you must get a Certificate of Death from the province or territory where they died. \n\n<br><br>\nClick here for other Vital Statistics Agencies in Canada. \nhttps://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\n\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n"
+                            "body": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. You can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n<br><br>\n<a href=\"https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\" target=\"_blank\">Click here for more information from the Government of British Columbia's website.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of British Columbia but still inside of Canada, you must get a Certificate of Death from the province or territory where they died. \n<br><br>\n<a href=\"https://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\" target=\"_blank\">Click here for other Vital Statistics Agencies in Canada.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. "
                         },
                         {
                             "type": "infotext",
                             "name": "question412",
                             "visible": false,
-                            "title": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. \n<br>\nYou can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n\nVisit the Government of British Columbia website for more information. https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\n\n<br><br>\nIf {deceasedName} died outside of British Columbia but still in Canada, you must get a Certificate of Death from the province or territory where they died. \n\n<br><br>\nClick here for other Vital Statistics Agencies in Canada. \nhttps://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\n\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n",
+                            "title": "A `Certificate of Death` comes from the place where {deceasedName} died.\n<br><br>\nIf {deceasedName} died in British Columbia, their Certificate of Death comes from the Vital Statistics Agency of British Columbia. You can get a Certificate of Death directly from Vital Statistics or you can ask a funeral home to get a Certificate of Death for you.\n<br><br>\n<a href=\"https://www2.gov.bc.ca/gov/content/life-events/death/death-certificates\" target=\"_blank\">Click here for more information from the Government of British Columbia's website.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of British Columbia but still inside of Canada, you must get a Certificate of Death from the province or territory where they died. \n<br><br>\n<a href=\"https://www.statcan.gc.ca/eng/about/relevant/vscc/organisations\" target=\"_blank\">Click here for other Vital Statistics Agencies in Canada.</a> (This link opens in a new tab)\n<br><br>\nIf {deceasedName} died outside of Canada, you must get a Certificate of Death from the state or country where they died. \n",
                             "titleLocation": "hidden"
                         }
                     ],
@@ -120,7 +120,7 @@
                         {
                             "type": "address",
                             "name": "deceasedAddress",
-                            "title": "What was {deceasedName} last known address?",
+                            "title": "What was {deceasedName}'s last known address?",
                             "description": "If {deceasedName} was homeless:\n<ul>\n<li>write \"no fixed address\" for the street address</li>\n<li>Write the city/town, province and country where they lived.</li>\n<li>Write \"n/a\" for their postal code.</li>\n</ul>"
                         },
                         {
@@ -143,16 +143,8 @@
                             "type": "infotext",
                             "name": "question438",
                             "visible": false,
-                            "title": "[Obsolete - Will questions determine which asset affidavit to use regardless of where the address is]\n<br><br>\nThis service can help you extend the powers of a `Representation Grant` from another place.\n<br><br>\nIt makes sense to first get a `Representation Grant` from where {deceasedName} spent most of their time. There may be benefits to getting grants in this order that a lawyer can explain to you. [link to lawyer info]\n<br><br>\nIf you don't already have a Representation Grant from the place where {deceasedName} spent most of their time, this service can still help you apply for a B.C. Representation Grant.  ",
+                            "title": "[Location triggered Explanation Obsolete here?? - Will questions determine which asset affidavit to use regardless of where the address is]\n<br><br>\nThis service can help you extend the powers of a `Representation Grant` from another place.\n<br><br>\nIt makes sense to first get a `Representation Grant` from where {deceasedName} spent most of their time. There may be benefits to getting grants in this order that a lawyer can explain to you. [link to lawyer info]\n<br><br>\nIf you don't already have a Representation Grant from the place where {deceasedName} spent most of their time, this service can still help you apply for a B.C. Representation Grant.  ",
                             "titleLocation": "hidden"
-                        },
-                        {
-                            "type": "infotext",
-                            "name": "question398",
-                            "visible": false,
-                            "title": "[Obsolete?? Probably still useful if not for P10/P11 then service addresses] <a href=\"https://justice.gov.bc.ca/jira/browse/REPGRANT-3X\" target=\"_blank\">JIRA ticket REPGRANT3X - Location Trigger</a>\n<br><br>TB Finished\nMay need location data to figure out which asset form to use: P10 or P11",
-                            "titleLocation": "hidden",
-                            "messageStyle": "error"
                         },
                         {
                             "type": "infotext",
@@ -204,19 +196,20 @@
                         },
                         {
                             "type": "infotext",
-                            "name": "firstNationsNameTrello",
+                            "name": "deceasedFirstNationsNotifyExplanation",
                             "visible": false,
-                            "title": "<a href=\"https://trello.com/c/cD8xmZY9\" target=\"_blank\">Trello - Radio Logic: notempty not working</a>\n<br><br>\nJIRA Ticket to be created; Copied from Trello:\n<br><br>\n{firstNationsName} is a radio button question.\n{deceasedExitPanel} has a visibleIf condition that includes {firstNationsName} notempty\n<br><br>\nThe problem is {deceasedExitPanel} shows even if {firstNationsName} has no selection",
-                            "titleLocation": "hidden",
-                            "messageStyle": "error"
+                            "visibleIf": "{deceasedFirstNations} =\"y\" and {deceasedFirstNationsName} notempty",
+                            "title": "This service will tell you how to notify the {deceasedFirstNationsName} Nation in a later step.",
+                            "isRequired": true,
+                            "titleLocation": "hidden"
                         },
                         {
                             "type": "infotext",
-                            "name": "question460",
+                            "name": "question13",
                             "visible": false,
-                            "title": "This service will tell you how to notify the Nation in a later step.",
-                            "isRequired": true,
-                            "titleLocation": "hidden"
+                            "title": "double check that the variable substitution from {deceasedFirstNationsName} updates in real-time in the deployed version for {deceasedFirstNationsNotifyExplanation}",
+                            "titleLocation": "hidden",
+                            "messageStyle": "error"
                         }
                     ],
                     "visible": false,
@@ -234,7 +227,7 @@
                         }
                     ],
                     "visible": false,
-                    "visibleIf": "{deceasedName} notempty and {deceasedDateOfDeath} notempty and {deceasedAddress} notempty and ({deceasedFirstNations} = \"n\" or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty))"
+                    "visibleIf": "{deceasedName} notempty and {deceasedDateOfDeath} notempty and {deceasedAddress} notempty and ({deceasedFirstNations} = \"n\" or ({deceasedFirstNations} = \"y\" and {deceasedFirstNationsName} notempty and {deceasedFirstNationsNotifyExplanation} >0))"
                 }
             ],
             "title": "Information about {deceasedName}"

--- a/web/src/components/steps/will/DeceasedWill.vue
+++ b/web/src/components/steps/will/DeceasedWill.vue
@@ -39,6 +39,9 @@ export default class DeceasedWill extends Vue {
     public deceasedName!: string;
 
     @applicationState.Action
+    public UpdateStepActive!: (newStepActive) => void
+
+    @applicationState.Action
     public UpdateGotoPrevStepPage!: () => void
 
     @applicationState.Action
@@ -91,16 +94,20 @@ export default class DeceasedWill extends Vue {
             if(options.name == "willCheck") {
                 if (options.value == "n") {
                     this.disableNextButton = true;
+                    this.toggleSteps([2, 3, 4, 5, 6, 7, 8], false)
                 } else {
                     this.disableNextButton = false;
+                     this.toggleSteps([2, 3, 4, 5, 6, 7, 8], true)
                 }                
             }
 
             if(options.name == "willGrantExists") {
                 if (options.value == "y") {
                     this.disableNextButton = true;
+                     this.toggleSteps([2, 3, 4, 5, 6, 7, 8], false)
                 } else {
                     this.disableNextButton = false;
+                     this.toggleSteps([2, 3, 4, 5, 6, 7, 8], true)
                 }                
             }
 
@@ -121,6 +128,15 @@ export default class DeceasedWill extends Vue {
         Vue.filter('setSurveyProgress')(this.survey, this.currentStep, this.currentPage, 50, false);
 
         this.survey.setVariable("deceasedName", Vue.filter('getFullName')(this.deceasedName));
+    }   
+
+    public toggleSteps(stepArr, activeIndicator) {
+        for (let i = 0; i < stepArr.length; i++) {
+            this.UpdateStepActive({
+                currentStep: stepArr[i],
+                active: activeIndicator
+            });
+        }
     }
 
     public onPrev() {

--- a/web/src/store/modules/application.ts
+++ b/web/src/store/modules/application.ts
@@ -22,7 +22,7 @@ class Application extends VuexModule {
     public applicantName = ""
     public deceasedName = {"first":"(the person","middle":"who","last":"died)"};
     public deceasedDateOfDeath = null
-    public deceasedDateOfDeathPlus4 = ""
+    public deceasedDateOfDeathPlus4 = "(the Five-day survival rule)"
     public dateOfWill = null
     public deceasedChildrenInfo = []
     public deceasedGrandChildrenInfo = []

--- a/web/src/store/modules/application.ts
+++ b/web/src/store/modules/application.ts
@@ -20,7 +20,7 @@ class Application extends VuexModule {
     public userName = ""
     public userId = ""
     public applicantName = ""
-    public deceasedName = ""
+    public deceasedName = {"first":"(the person","middle":"who","last":"died)"};
     public deceasedDateOfDeath = null
     public deceasedDateOfDeathPlus4 = ""
     public dateOfWill = null
@@ -38,6 +38,7 @@ class Application extends VuexModule {
         this.allCompleted = false;
         this.currentStep = 0;
         this.type = "probate";
+        this.deceasedName = {"first":"(the person","middle":"who","last":"died)"};
         this.userName = "";
         this.lastPrinted = null;
         this.lastUpdate = null;


### PR DESCRIPTION
Changes include: 

- REPGRANT-77: Made changes to the deceased info page based on requirements described in REPGRANT-79 
- REPGRANT-82: 
    - Added json provided by Jack Sam 
    - Added default-substitution functionality to the "spouse name" field 
- REPGRANT-101: Adding default-substitution for the deceased-name to all pages of the survey 
- Make changes based on feedback: 
    - REPGRANT-19:  
        - applied latest json 
        - Updated qualification conditions based on changes in the survey-json 
        - Changed the "Complete" button to "Next" 
    - REPGRANT-31: added default-substitution