### PR TITLE
REPGRANT-177 and 164 Fixes/Updates

### DIFF
--- a/web/src/components/survey/question-typesII.ts
+++ b/web/src/components/survey/question-typesII.ts
@@ -185,26 +185,42 @@ function initHelpText(Survey) {
       header.appendChild(lbl);
       outer.appendChild(header);
 
-      const body = document.createElement("div");
-      body.className = "panel-body";
-      outer.appendChild(body);
+      let body = null;
+      const createUpdateBody = () => {
+        if (body) {
+          const bodyContent = question.body || "";
+          const bodyHtml = question.getMarkdownHtml(bodyContent);
+          if (bodyHtml !== null)
+            body.innerHTML = question.getProcessedHtml(bodyHtml);
+          else body.innerText = question.getProcessedHtml(bodyContent);
+        }
+        else {
+          body = document.createElement("div");
+          body.className = "panel-body";
+          outer.appendChild(body);
+          createUpdateBody();
+        }
+      }
+      if (question.body) 
+        createUpdateBody();
+
       el.appendChild(outer);
 
-      const updateContent = () => {
+      const updateTitle = () => {
         const titleContent = question.fullTitle;
         title.innerHTML = titleContent;
-
-        const bodyContent = question.body || "";
-        const bodyHtml = question.getMarkdownHtml(bodyContent);
-        if (bodyHtml !== null)
-          body.innerHTML = question.getProcessedHtml(bodyHtml);
-        else body.innerText = question.getProcessedHtml(bodyContent);
       };
-      question.titleChangedCallback = updateContent;
-      updateContent();
+      question.titleChangedCallback = updateTitle;
+      updateTitle();
       
-      question.registerFunctionOnPropertyValueChanged("title", () => {
-        updateContent();
+      question.registerFunctionOnPropertyValueChanged("title", updateTitle());
+      question.registerFunctionOnPropertyValueChanged("body", () => {
+        if (!question.body) {
+          el.getElementsByClassName("panel-body").forEach(e => e.remove());
+          body = null;
+        }
+        else
+          createUpdateBody();
       });
       
       question.valueChangedCallback = function() {
@@ -214,8 +230,6 @@ function initHelpText(Survey) {
           (question.value ? "fa fa-chevron-up" : "fa fa-chevron-down");
       };
       question.valueChangedCallback();
-
-      
     },
     willUnmount: function(question, el) {}
   };
@@ -280,11 +294,23 @@ function initInfoText(Survey: any) {
       outer.appendChild(header);
 
       let body = null;
-      if (question.body) {
-        body = document.createElement("div");
-        body.className = "panel-body";
-        outer.appendChild(body);
+      const createUpdateBody = () => {
+        if (body) {
+          const bodyContent = question.body || "";
+          const bodyHtml = question.getMarkdownHtml(bodyContent);
+          if (bodyHtml !== null)
+            body.innerHTML = question.getProcessedHtml(bodyHtml);
+          else body.innerText = question.getProcessedHtml(bodyContent);
+        }
+        else {
+          body = document.createElement("div");
+          body.className = "panel-body";
+          outer.appendChild(body);
+          createUpdateBody();
+        }
       }
+      if (question.body)
+        createUpdateBody();
 
       const showContinueButton = () => {
         if (question.isRequired && !question.value) {
@@ -319,23 +345,21 @@ function initInfoText(Survey: any) {
 
       el.appendChild(outer);
 
-      const updateContent = () => {
+      const updateTitle = () => {
         const titleContent = question.fullTitle;
         title.innerHTML = titleContent;
-
-        if (body) {
-          const bodyContent = question.body || "";
-          const bodyHtml = question.getMarkdownHtml(bodyContent);
-          if (bodyHtml !== null)
-            body.innerHTML = question.getProcessedHtml(bodyHtml);
-          else body.innerText = question.getProcessedHtml(bodyContent);
-        }
       };
-      //question.titleChangedCallback = updateContent;
-      updateContent();
+      question.titleChangedCallback = updateTitle;
+      updateTitle();
 
-      question.registerFunctionOnPropertyValueChanged("title", () => {
-        updateContent();
+      question.registerFunctionOnPropertyValueChanged("title", updateTitle());
+      question.registerFunctionOnPropertyValueChanged("body", () => {
+        if (!question.body) {
+          el.getElementsByClassName("panel-body").forEach(e => e.remove());
+          body = null;
+        }
+        else
+          createUpdateBody();
       });
     },
     willUnmount: function(question, el) {}

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -258,7 +258,7 @@ $indicator-thickness: 0.2em;
 $font-size: 11px;
 
 main.app-content.fill-body {
-  height: 766px;
+  height: 740px;
 }
 
 .svd_container.sv_bootstrap_css .svd-tabs {
@@ -269,8 +269,8 @@ main.app-content.fill-body {
 }
 
 .svd_container .svd_content {
-  padding: 0px 15px 1px 15px;
-  height: 766px;
+  padding: 0px 0px 1px 5px;
+  height: 740px;
 }
 
 .svd-toolbar-dropdown__select {
@@ -325,13 +325,14 @@ main.app-content.fill-body {
   }
   .svd_object_editor {
     font-size: $font-size;
+    margin-right: 8px;
     padding: 1px 5px 1px 1px;
     .form-control {
       font-size: $font-size;
     }
   }
   textarea {
-    height: 8em !important;
+    min-height: 8em;
   }
 }
 
@@ -366,4 +367,9 @@ main.app-content.fill-body {
 // Hide toolbar in JSON Editor
 survey-json-editor .svd_toolbar {
   display: none;
+}
+
+// Show the expanding faq description
+.svd_editors .survey-expander .panel-body {
+  display: -webkit-box;
 }


### PR DESCRIPTION
177:
I see that content for the "Title" and "Description" properties gets refreshed instantly. 
Can we extend this refresh rate to the "Body" property of both "Message Text" and "Expanding FAQ" question types?

164:
- I see the extra cellpadding has been added but the scrollbar just moved along with it and covers the draggable corner. Is it possible to move that scroll bar over?

- I see the height of the boxes have now doubled. But it seems the ability to drag it bigger or small has been locked. Can the input boxes remain doubled in height but be able to adjust?

- The properties column is cut off pretty abruptly. The middle column (survey contents) seems fine by comparison. 