### PR TITLE
Repgrant 54 - Updates to Custom Date Feedback

### DIFF
--- a/web/src/components/survey/components/CustomDate.vue
+++ b/web/src/components/survey/components/CustomDate.vue
@@ -109,17 +109,18 @@ export default {
       if (q.pastDateHandler === "Years Behind") {
         firstYear -= q.yearsBehind;
       } else if (q.pastDateHandler === "Earliest Date") {
-        firstYear = parseInt(q.earliestDate.split("-")[0]);
+        console.log(q.earliestDate);
+        firstYear = q.earliestDate ? parseInt(q.earliestDate.split("-")[0]) : firstYear;
       } else if (q.pastDateHandler === "Past Reference Variable") {
-        firstYear = parseInt(this.pastDate.split("-")[0]) || firstYear;
+        firstYear = this.pastDate ? parseInt(this.pastDate.split("-")[0]) : firstYear;
       }
 
       if (q.futureDateHandler === "Years Ahead") {
         curYear += q.yearsAhead;
       } else if (q.futureDateHandler === "Latest Date") {
-        curYear = parseInt(q.latestDate.split("-")[0]);
+        curYear = q.latestDate ? parseInt(q.latestDate.split("-")[0]) : curYear;
       } else if (q.futureDateHandler === "Future Reference Variable") {
-        curYear = parseInt(this.futureDate.split("-")[0]) || curYear;
+        curYear = this.futureDate ? parseInt(this.futureDate.split("-")[0]) : curYear;
       }
 
       const opts = [];
@@ -155,8 +156,8 @@ export default {
 
       if (q.pastDateHandler !== "Years Behind") {
         const pastDateItems = {
-          "Earliest Date": q.earliestDate.split("-"),
-          "Past Reference Variable": this.pastDate.split("-")
+          "Earliest Date": q.earliestDate ? q.earliestDate.split("-") : "",
+          "Past Reference Variable": this.pastDate ? this.pastDate.split("-") : ""
         }[q.pastDateHandler];
 
         const earliestDate = new Date(pastDateItems[0], pastDateItems[1] - 1, pastDateItems[2]);
@@ -165,8 +166,8 @@ export default {
 
       if (q.futureDateHandler !== "Years Ahead") {
         const futureDateItems = {
-          "Latest Date": q.latestDate.split("-"),
-          "Future Reference Variable": this.futureDate.split("-")
+          "Latest Date": q.latestDate ? q.latestDate.split("-") : "",
+          "Future Reference Variable": this.futureDate ? this.futureDate.split("-") : ""
         }[q.futureDateHandler];
 
         const latestDate = new Date(futureDateItems[0], futureDateItems[1] - 1, futureDateItems[2]);
@@ -195,8 +196,8 @@ export default {
 
       if (q.pastDateHandler !== "Years Behind") {
         const pastDateItems = {
-          "Earliest Date": q.earliestDate.split("-"),
-          "Past Reference Variable": this.pastDate.split("-")
+          "Earliest Date": q.earliestDate ? q.earliestDate.split("-") : "",
+          "Past Reference Variable": this.pastDate ? this.pastDate.split("-") : ""
         }[q.pastDateHandler];
 
         const earliestDate = new Date(pastDateItems[0], pastDateItems[1] - 1, pastDateItems[2]);
@@ -208,8 +209,8 @@ export default {
 
       if (q.futureDateHandler !== "Years Ahead") {
         const futureDateItems = {
-          "Latest Date": q.latestDate.split("-"),
-          "Future Reference Variable": this.futureDate.split("-")
+          "Latest Date": q.latestDate ? q.latestDate.split("-") : "",
+          "Future Reference Variable": this.futureDate ? this.futureDate.split("-") : ""
         }[q.futureDateHandler];
 
         const latestDate = new Date(futureDateItems[0], futureDateItems[1] - 1, futureDateItems[2]);

--- a/web/src/components/survey/components/CustomDate.vue
+++ b/web/src/components/survey/components/CustomDate.vue
@@ -109,7 +109,6 @@ export default {
       if (q.pastDateHandler === "Years Behind") {
         firstYear -= q.yearsBehind;
       } else if (q.pastDateHandler === "Earliest Date") {
-        console.log(q.earliestDate);
         firstYear = q.earliestDate ? parseInt(q.earliestDate.split("-")[0]) : firstYear;
       } else if (q.pastDateHandler === "Past Reference Variable") {
         firstYear = this.pastDate ? parseInt(this.pastDate.split("-")[0]) : firstYear;

--- a/web/src/components/survey/components/DateMath.vue
+++ b/web/src/components/survey/components/DateMath.vue
@@ -64,7 +64,7 @@ export default defineComponent({
       };
 
       function dateFromNameOfVariable(dateString) {
-        if ((dateString.includes("{") && dateString.includes("}")) || !dateString) {
+        if (!dateString || (dateString.includes("{") && dateString.includes("}"))) {
           return;
         }
 
@@ -80,10 +80,6 @@ export default defineComponent({
         return date;
       }
 
-      const dateFormatter = date => {
-        return date.toLocaleString("en-US", { year: "numeric", month: "long", day: "numeric" });
-      };
-
       const calcDate = dateString => {
         const date = dateFromNameOfVariable(dateString);
         const offset = q.daysToOffset;
@@ -95,9 +91,9 @@ export default defineComponent({
 
         if (daysType === "Calendar Days") {
           date.setDate(date.getDate() + offset);
-          return dateFormatter(date);
+          return date;
         } else if (daysType === "Business Days") {
-          return dateFormatter(calcBusinessDays(date, offset));
+          return calcBusinessDays(date, offset);
         }
       }
 
@@ -108,7 +104,7 @@ export default defineComponent({
         text = convertTicksToToolTip(text);
 
         // We want to update value if we get here.
-        state.value = dateFormatter(calcDate(text));
+        state.value = calcDate(text);
         q.value = state.value;
 
         return text;

--- a/web/src/components/survey/components/DateMath.vue
+++ b/web/src/components/survey/components/DateMath.vue
@@ -80,6 +80,14 @@ export default defineComponent({
         return date;
       }
 
+      function dateFormatter(date) {
+        const year = date.getFullYear();
+        const month = date.getMonth() + 1;
+        const day = date.getDate();
+
+        return year + "-" + month + "-" + day;
+      }
+
       const calcDate = dateString => {
         const date = dateFromNameOfVariable(dateString);
         const offset = q.daysToOffset;
@@ -91,9 +99,9 @@ export default defineComponent({
 
         if (daysType === "Calendar Days") {
           date.setDate(date.getDate() + offset);
-          return date;
+          return dateFormatter(date);
         } else if (daysType === "Business Days") {
-          return calcBusinessDays(date, offset);
+          return dateFormatter(calcBusinessDays(date, offset));
         }
       }
 

--- a/web/src/components/survey/survey-expressions.ts
+++ b/web/src/components/survey/survey-expressions.ts
@@ -153,6 +153,22 @@ export const addCustomExpressions = (Survey: any) => {
     return earliestSubmissionDate;
   };
 
+  //Parameters: {questionName} for date.
+  const dateFormatter = params => {
+    if (!params) return "";
+    if (!params[0]) return "";
+
+    const temp = new Date(params[0]);
+    // plugging in date is one day short for some reason,
+    // need to add back the extra
+    const date = new Date(temp.getFullYear(), temp.getMonth(), temp.getDate() + 1);
+    return date.toLocaleString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric"
+    });
+  };
+
   //Add this so ExpressionRunner can access it.
   FunctionFactory.Instance.register("listIntersect", listIntersect);
   FunctionFactory.Instance.register("listExcept", listExcept);
@@ -165,6 +181,7 @@ export const addCustomExpressions = (Survey: any) => {
   );
   FunctionFactory.Instance.register("getParticipants", getParticipants);
   FunctionFactory.Instance.register("getNonParticipants", getNonParticipants);
+  FunctionFactory.Instance.register("dateFormatter", dateFormatter);
 
   Survey.FunctionFactory.Instance.register("listIntersect", listIntersect);
   Survey.FunctionFactory.Instance.register("listExcept", listExcept);
@@ -180,4 +197,5 @@ export const addCustomExpressions = (Survey: any) => {
   );
   Survey.FunctionFactory.Instance.register("getParticipants", getParticipants);
   Survey.FunctionFactory.Instance.register("getNonParticipants", getNonParticipants);
+  Survey.FunctionFactory.Instance.register("dateFormatter", dateFormatter);
 };

--- a/web/src/components/survey/survey-expressions.ts
+++ b/web/src/components/survey/survey-expressions.ts
@@ -158,15 +158,23 @@ export const addCustomExpressions = (Survey: any) => {
     if (!params) return "";
     if (!params[0]) return "";
 
-    const temp = new Date(params[0]);
-    // plugging in date is one day short for some reason,
-    // need to add back the extra
-    const date = new Date(temp.getFullYear(), temp.getMonth(), temp.getDate() + 1);
-    return date.toLocaleString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric"
-    });
+    const date = new Date(params[0]);
+    enum Months {
+      January,
+      February,
+      March,
+      April,
+      May,
+      June,
+      July,
+      August,
+      September,
+      October,
+      November,
+      December
+    }
+
+    return Months[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
   };
 
   //Add this so ExpressionRunner can access it.

--- a/web/survey-js-examples/date-widgets.json
+++ b/web/survey-js-examples/date-widgets.json
@@ -1,0 +1,40 @@
+{
+  "pages": [
+   {
+    "name": "page1",
+    "elements": [
+     {
+      "type": "customdate",
+      "name": "question1",
+      "title": "Custom Date",
+      "pastDateHandler": "Earliest Date",
+      "earliestDate": "2014-03-31",
+      "yearsAhead": 15
+     },
+     {
+      "type": "datemath",
+      "name": "question2",
+      "title": "Date Math, +10 calendar days",
+      "referenceVariable": "{question1}",
+      "daysToOffset": 10
+     },
+     {
+      "type": "expression",
+      "name": "question3",
+      "visible": false,
+      "title": "Formatting for readability",
+      "expression": "dateFormatter({question2})"
+     },
+     {
+      "type": "customdate",
+      "name": "question4",
+      "title": "Using Date Math calc in Custom Date (earliest date is {question3})",
+      "pastDateHandler": "Past Reference Variable",
+      "pastReferenceVariable": "{question2}",
+      "yearsAhead": 15
+     }
+    ],
+    "title": "Date Widgets Example usage"
+   }
+  ]
+ }


### PR DESCRIPTION
This PR addresses some issues detected during the feedback session. Most notably the issue with unset variables being calculated without being used. Furthermore the output of date-related widgets (`CustomDate` & `DateMath`) have been standardized to match that of `SingleInput - date` which is the for `yyyy-mm-dd`. An expression has been added to handle the "pretty printing" of the date in the form `mmmm dd, yyyy`.