### PR TITLE
REPGRANT 242 - Remove complete button

### DIFF
--- a/web/src/components/NavigationTopbar.vue
+++ b/web/src/components/NavigationTopbar.vue
@@ -113,7 +113,7 @@ export default class NavigationTopbar extends Vue {
 @import "@/styles/_common";
 
 .navbar {
-  overflow: hidden;
+  overflow: visible;
   position: fixed;
   top: 0;
   width: 100%;

--- a/web/src/components/SurveyMain.vue
+++ b/web/src/components/SurveyMain.vue
@@ -120,6 +120,11 @@ export default defineComponent({
 
       survey.value.onCurrentPageChanged.add((sender, options) => {
         updatedKey.value++;
+
+        const maxPage = survey.value.pages.filter(p => p.isVisible).length - 1;
+        if(maxPage === survey.value.currentPageNo) survey.value.showNavigationButtons = false;
+        else survey.value.showNavigationButtons = true;
+
         saveTimer();
         Vue.nextTick(() => {
           const el = document.getElementById("sidebar-title");

--- a/web/src/components/SurveyMain.vue
+++ b/web/src/components/SurveyMain.vue
@@ -120,11 +120,6 @@ export default defineComponent({
 
       survey.value.onCurrentPageChanged.add((sender, options) => {
         updatedKey.value++;
-
-        const maxPage = survey.value.pages.filter(p => p.isVisible).length - 1;
-        if(maxPage === survey.value.currentPageNo) survey.value.showNavigationButtons = false;
-        else survey.value.showNavigationButtons = true;
-
         saveTimer();
         Vue.nextTick(() => {
           const el = document.getElementById("sidebar-title");

--- a/web/src/components/home/PreQualification.vue
+++ b/web/src/components/home/PreQualification.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container class="container home-content">
+  <b-container class="container home-content" style="margin-bottom: 56px;">
     <survey :survey="survey"></survey>
     <b-button v-if="displayButton" @click="onSubmit" variant="success">
       <b-icon-check-circle-fill /> Next

--- a/web/src/styles/_survey.scss
+++ b/web/src/styles/_survey.scss
@@ -114,6 +114,10 @@
   .sv-radio > label {
     display: block; // fix alignment on checkbox row
   }
+
+  .sv_complete_btn {
+    visibility: hidden;
+  }
 }
 
 .svd_container survey-widget .form-inline .form-control {


### PR DESCRIPTION
This PR removes the complete button from the last page of the survey. One concern is that it also removes the `previous` button as well. We may want to discuss with Jack how we want this handled.