### PR TITLE
Repgrant 33 - Address Widget Update

### DIFF
--- a/web/src/components/survey/AddressInfo.vue
+++ b/web/src/components/survey/AddressInfo.vue
@@ -139,7 +139,6 @@ export default {
       addrs.sort((a, b) => a.label.localeCompare(b.label));
       return addrs;
     },
-    //updateValue(_evt) {
     updateValue() {
       const value = Object.assign({}, this.pendingValue);
       for (const k in value) {
@@ -171,6 +170,7 @@ export default {
         this.readOnly = true;
         this.pendingValue = this.loadValue(e.target.options[selIndex]._value);
       }
+      this.updateValue();
     }
   },
   computed: {

--- a/web/src/components/survey/AddressInfo.vue
+++ b/web/src/components/survey/AddressInfo.vue
@@ -1,17 +1,16 @@
 <template>
   <div class="survey-address">
-    <!-- <div class="row survey-address-line" v-if="selOptions.length">
+    <div class="row survey-address-line" v-if="selOptions.length">
       <div class="col-sm-6 form-inline">
         <label class="survey-sublabel">Copy from:</label>
-        <select class="form-control ml-2" ref="copyFrom">
+        <select class="form-control ml-2" ref="copyFrom" @change="fillInData">
           <option value="">(Select Address)</option>
           <option v-for="(opt, inx) in selOptions" :key="inx" :value="opt.value">{{
             opt.label
           }}</option>
         </select>
       </div>
-    </div> -->
-    <!-- Address, City, Province, Postalcode, Country -->
+    </div>
     <div class="row survey-address-line">
       <div class="col-sm-6">
         <input
@@ -20,6 +19,7 @@
           :id="question.inputId"
           v-model="pendingValue['street']"
           @change="updateValue"
+          :readonly="readOnly"
         />
       </div>
     </div>
@@ -31,6 +31,7 @@
           :id="question.inputId + '-city'"
           v-model="pendingValue['city']"
           @change="updateValue"
+          :readonly="readOnly"
         />
       </div>
     </div>
@@ -44,6 +45,7 @@
           v-model="pendingValue['state']"
           :id="question.inputId + '-state'"
           @change="updateValue"
+          :disabled="readOnly"
         >
           <option v-for="reg of regionOptions" :key="reg.value" :value="reg.value">{{
             reg.text
@@ -59,6 +61,7 @@
           v-model="pendingValue['country']"
           :id="question.inputId + '-country'"
           @change="updateValue"
+          :disabled="readOnly"
         >
           <option v-for="coun of countryOptions" :key="coun.value" :value="coun.value">{{
             coun.text
@@ -74,6 +77,7 @@
           :id="question.inputId + '-postcode'"
           v-model="pendingValue['postcode']"
           @change="updateValue"
+          :readonly="readOnly"
         />
       </div>
     </div>
@@ -91,7 +95,8 @@ export default {
       countryOptions: [canada, usa],
       selOptions: [],
       pendingValue: this.loadValue(this.question.value),
-      value: this.question.value
+      value: this.question.value,
+      readOnly: false
     };
   },
   methods: {
@@ -155,6 +160,17 @@ export default {
         postcode: val.postcode || ""
       };
       return pending;
+    },
+    fillInData(e) {
+      console.log("SELECTION MADE");
+      const selIndex = e.target.options.selectedIndex;
+      if (selIndex === 0) {
+        this.readOnly = false;
+        this.pendingValue = this.loadValue();
+      } else if (selIndex > -1) {
+        this.readOnly = true;
+        this.pendingValue = this.loadValue(e.target.options[selIndex]._value);
+      }
     }
   },
   computed: {

--- a/web/src/components/survey/AddressInfo.vue
+++ b/web/src/components/survey/AddressInfo.vue
@@ -42,9 +42,8 @@
           :id="question.inputId + '-state'"
           @change="updateValue"
         >
-          <option value="">(Select)</option>
-          <option v-for="prov of provinceOptions" :key="prov.value" :value="prov.value">{{
-            prov.text
+          <option v-for="reg of regionOptions" :key="reg.value" :value="reg.value">{{
+            reg.text
           }}</option>
         </select>
       </div>
@@ -58,7 +57,6 @@
           :id="question.inputId + '-country'"
           @change="updateValue"
         >
-          <option value="">(Select)</option>
           <option v-for="coun of countryOptions" :key="coun.value" :value="coun.value">{{
             coun.text
           }}</option>
@@ -78,76 +76,14 @@
 </template>
 
 <script>
+import { canada, provinces, usa, states } from "@/utils/location-options";
 export default {
   props: {
     question: Object
   },
   data() {
     return {
-      provinceOptions: [
-        {
-          value: "AB",
-          text: "Alberta"
-        },
-        {
-          value: "BC",
-          text: "British Columbia"
-        },
-        {
-          value: "MB",
-          text: "Manitoba"
-        },
-        {
-          value: "NB",
-          text: "New Brunswick"
-        },
-        {
-          value: "NF",
-          text: "Newfoundland and Labrador"
-        },
-        {
-          value: "NT",
-          text: "Northwest Territories"
-        },
-        {
-          value: "NS",
-          text: "Nova Scotia"
-        },
-        {
-          value: "NU",
-          text: "Nunavut"
-        },
-        {
-          value: "ON",
-          text: "Ontario"
-        },
-        {
-          value: "PE",
-          text: "Prince Edward Island"
-        },
-        {
-          value: "QC",
-          text: "Quebec"
-        },
-        {
-          value: "SK",
-          text: "Saskatchewan"
-        },
-        {
-          value: "YT",
-          text: "Yukon"
-        }
-      ],
-      countryOptions: [
-        {
-          value: "CAN",
-          text: "Canada"
-        },
-        {
-          value: "USA",
-          text: "USA"
-        }
-      ],
+      countryOptions: [canada, usa],
       selOptions: [],
       pendingValue: this.loadValue(this.question.value),
       value: this.question.value
@@ -214,6 +150,19 @@ export default {
         postcode: val.postcode || ""
       };
       return pending;
+    }
+  },
+  computed: {
+    regionOptions() {
+      const p = this.pendingValue;
+
+      if (p && p.country) {
+        return p.country === "CAN"
+          ? provinces
+          : states
+      } else {
+        return provinces.concat(states);
+      }
     }
   },
   mounted() {

--- a/web/src/components/survey/AddressInfo.vue
+++ b/web/src/components/survey/AddressInfo.vue
@@ -11,8 +11,9 @@
         </select>
       </div>
     </div> -->
+    <!-- Address, City, Province, Postalcode, Country -->
     <div class="row survey-address-line">
-      <div class="col-sm-12">
+      <div class="col-sm-6">
         <input
           class="form-control"
           placeholder="Street address, for example: 800 Hornby St. or Post Office Box"
@@ -32,6 +33,8 @@
           @change="updateValue"
         />
       </div>
+    </div>
+    <div class="row survey-address-line">
       <div class="col-sm-6">
         <label class="survey-sublabel" :for="question.inputId + '-state'"
           >Province / State / Region</label
@@ -62,6 +65,8 @@
           }}</option>
         </select>
       </div>
+    </div>
+    <div class="row survey-address-line">
       <div class="col-sm-6">
         <label class="survey-sublabel" :for="question.inputId + '-postcode'">Postal Code</label>
         <input

--- a/web/src/survey/question-types/address-block-type.ts
+++ b/web/src/survey/question-types/address-block-type.ts
@@ -24,6 +24,48 @@ export function initAddressBlock(Survey: any) {
         null,
         "empty"
       );
+      Survey.JsonObject.metaData.addProperties("address", [
+        {
+          name: "useStreet:boolean",
+          category: "others",
+          default: true
+        },
+        {
+          name: "useCity:boolean",
+          category: "others",
+          default: true
+        },
+        {
+          name: "useProvince:boolean",
+          category: "others",
+          default: true
+        },
+        {
+          name: "useCountry:boolean",
+          category: "others",
+          default: true
+        },
+        {
+          name: "usePostalCode:boolean",
+          category: "others",
+          default: true
+        },
+        {
+          name: "useEmail:boolean",
+          category: "others",
+          default: false
+        },
+        {
+          name: "usePhone:boolean",
+          category: "others",
+          default: false
+        },
+        {
+          name: "useFax:boolean",
+          category: "others",
+          default: false
+        }
+      ]);
     },
     htmlTemplate: "<div></div>",
     afterRender: function(question, el) {

--- a/web/src/utils/location-options.ts
+++ b/web/src/utils/location-options.ts
@@ -73,10 +73,6 @@ export const states = [
         value: "AK"
     },
     {
-        text: "American Samoa",
-        value: "AS"
-    },
-    {
         text: "Arizona",
         value: "AZ"
     },
@@ -105,20 +101,12 @@ export const states = [
         value: "DC"
     },
     {
-        text: "Federated States Of Micronesia",
-        value: "FM"
-    },
-    {
         text: "Florida",
         value: "FL"
     },
     {
         text: "Georgia",
         value: "GA"
-    },
-    {
-        text: "Guam",
-        value: "GU"
     },
     {
         text: "Hawaii",
@@ -155,10 +143,6 @@ export const states = [
     {
         text: "Maine",
         value: "ME"
-    },
-    {
-        text: "Marshall Islands",
-        value: "MH"
     },
     {
         text: "Maryland",
@@ -221,10 +205,6 @@ export const states = [
         value: "ND"
     },
     {
-        text: "Northern Mariana Islands",
-        value: "MP"
-    },
-    {
         text: "Ohio",
         value: "OH"
     },
@@ -235,10 +215,6 @@ export const states = [
     {
         text: "Oregon",
         value: "OR"
-    },
-    {
-        text: "Palau",
-        value: "PW"
     },
     {
         text: "Pennsylvania",
@@ -275,10 +251,6 @@ export const states = [
     {
         text: "Vermont",
         value: "VT"
-    },
-    {
-        text: "Virgin Islands",
-        value: "VI"
     },
     {
         text: "Virginia",

--- a/web/src/utils/location-options.ts
+++ b/web/src/utils/location-options.ts
@@ -1,0 +1,303 @@
+export const canada = {
+    value: "CAN",
+    text: "Canada"
+}
+
+export const usa = {
+    value: "USA",
+    text: "USA"
+}
+
+export const provinces = [
+    {
+        value: "AB",
+        text: "Alberta"
+    },
+    {
+        value: "BC",
+        text: "British Columbia"
+    },
+    {
+        value: "MB",
+        text: "Manitoba"
+    },
+    {
+        value: "NB",
+        text: "New Brunswick"
+    },
+    {
+        value: "NF",
+        text: "Newfoundland and Labrador"
+    },
+    {
+        value: "NT",
+        text: "Northwest Territories"
+    },
+    {
+        value: "NS",
+        text: "Nova Scotia"
+    },
+    {
+        value: "NU",
+        text: "Nunavut"
+    },
+    {
+        value: "ON",
+        text: "Ontario"
+    },
+    {
+        value: "PE",
+        text: "Prince Edward Island"
+    },
+    {
+        value: "QC",
+        text: "Quebec"
+    },
+    {
+        value: "SK",
+        text: "Saskatchewan"
+    },
+    {
+        value: "YT",
+        text: "Yukon"
+    }
+];
+
+export const states = [
+    {
+        text: "Alabama",
+        value: "AL"
+    },
+    {
+        text: "Alaska",
+        value: "AK"
+    },
+    {
+        text: "American Samoa",
+        value: "AS"
+    },
+    {
+        text: "Arizona",
+        value: "AZ"
+    },
+    {
+        text: "Arkansas",
+        value: "AR"
+    },
+    {
+        text: "California",
+        value: "CA"
+    },
+    {
+        text: "Colorado",
+        value: "CO"
+    },
+    {
+        text: "Connecticut",
+        value: "CT"
+    },
+    {
+        text: "Delaware",
+        value: "DE"
+    },
+    {
+        text: "District Of Columbia",
+        value: "DC"
+    },
+    {
+        text: "Federated States Of Micronesia",
+        value: "FM"
+    },
+    {
+        text: "Florida",
+        value: "FL"
+    },
+    {
+        text: "Georgia",
+        value: "GA"
+    },
+    {
+        text: "Guam",
+        value: "GU"
+    },
+    {
+        text: "Hawaii",
+        value: "HI"
+    },
+    {
+        text: "Idaho",
+        value: "ID"
+    },
+    {
+        text: "Illinois",
+        value: "IL"
+    },
+    {
+        text: "Indiana",
+        value: "IN"
+    },
+    {
+        text: "Iowa",
+        value: "IA"
+    },
+    {
+        text: "Kansas",
+        value: "KS"
+    },
+    {
+        text: "Kentucky",
+        value: "KY"
+    },
+    {
+        text: "Louisiana",
+        value: "LA"
+    },
+    {
+        text: "Maine",
+        value: "ME"
+    },
+    {
+        text: "Marshall Islands",
+        value: "MH"
+    },
+    {
+        text: "Maryland",
+        value: "MD"
+    },
+    {
+        text: "Massachusetts",
+        value: "MA"
+    },
+    {
+        text: "Michigan",
+        value: "MI"
+    },
+    {
+        text: "Minnesota",
+        value: "MN"
+    },
+    {
+        text: "Mississippi",
+        value: "MS"
+    },
+    {
+        text: "Missouri",
+        value: "MO"
+    },
+    {
+        text: "Montana",
+        value: "MT"
+    },
+    {
+        text: "Nebraska",
+        value: "NE"
+    },
+    {
+        text: "Nevada",
+        value: "NV"
+    },
+    {
+        text: "New Hampshire",
+        value: "NH"
+    },
+    {
+        text: "New Jersey",
+        value: "NJ"
+    },
+    {
+        text: "New Mexico",
+        value: "NM"
+    },
+    {
+        text: "New York",
+        value: "NY"
+    },
+    {
+        text: "North Carolina",
+        value: "NC"
+    },
+    {
+        text: "North Dakota",
+        value: "ND"
+    },
+    {
+        text: "Northern Mariana Islands",
+        value: "MP"
+    },
+    {
+        text: "Ohio",
+        value: "OH"
+    },
+    {
+        text: "Oklahoma",
+        value: "OK"
+    },
+    {
+        text: "Oregon",
+        value: "OR"
+    },
+    {
+        text: "Palau",
+        value: "PW"
+    },
+    {
+        text: "Pennsylvania",
+        value: "PA"
+    },
+    {
+        text: "Puerto Rico",
+        value: "PR"
+    },
+    {
+        text: "Rhode Island",
+        value: "RI"
+    },
+    {
+        text: "South Carolina",
+        value: "SC"
+    },
+    {
+        text: "South Dakota",
+        value: "SD"
+    },
+    {
+        text: "Tennessee",
+        value: "TN"
+    },
+    {
+        text: "Texas",
+        value: "TX"
+    },
+    {
+        text: "Utah",
+        value: "UT"
+    },
+    {
+        text: "Vermont",
+        value: "VT"
+    },
+    {
+        text: "Virgin Islands",
+        value: "VI"
+    },
+    {
+        text: "Virginia",
+        value: "VA"
+    },
+    {
+        text: "Washington",
+        value: "WA"
+    },
+    {
+        text: "West Virginia",
+        value: "WV"
+    },
+    {
+        text: "Wisconsin",
+        value: "WI"
+    },
+    {
+        text: "Wyoming",
+        value: "WY"
+    }
+]

--- a/web/survey-js-examples/address.json
+++ b/web/survey-js-examples/address.json
@@ -1,0 +1,30 @@
+{
+    "pages": [
+     {
+      "name": "page1",
+      "elements": [
+       {
+        "type": "address",
+        "name": "Full Option Set",
+        "useEmail": true,
+        "usePhone": true,
+        "useFax": true
+       },
+       {
+        "type": "address",
+        "name": "Default Option Set"
+       }
+      ]
+     },
+     {
+      "name": "page2",
+      "elements": [
+       {
+        "type": "address",
+        "name": "Only the matching option will be available",
+        "isRequired": true
+       }
+      ]
+     }
+    ]
+   }


### PR DESCRIPTION
This PR brings a handful of changes detailed below.

### Facelift
The style has been modified to better match the desired look.
![image](https://user-images.githubusercontent.com/26128992/147145404-0500a7a2-f973-4a67-a2d5-77d2b9ec6269.png)

### Optional Fields
Every field in the address widget is optional.
![image](https://user-images.githubusercontent.com/26128992/147145757-14d8973a-8271-405f-a645-a48e3aceee39.png)

### Copying from previous entries
The `copy from:` feature would cause issues since the fields for the question were empty (even if the `value` of the question was set). Now, if a user selects from the dropdown, the appropriate fields are filled and made into `readOnly`.
![image](https://user-images.githubusercontent.com/26128992/147147852-54b3ad7a-b336-4558-ace0-177f9a312624.png)
Since the address widget can have any number of fields, only those that have the same fields will be available to copy from.

 